### PR TITLE
Move to pyproject, enable metal and CPU and venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,169 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Dataset!
+/dataset/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # [AAAI25] WiFi Temporal Activity Detection via Dual Pyramid Network
+
 Authors: *Zhendong Liu, Le Zhang, Bing Li, Yingjie Zhou, Zhenghua Chen and Ce Zhu*
 
 ## Abstract
+
 We address the challenge of WiFi-based temporal activity detection and  propose an efficient Dual Pyramid Network that integrates Temporal Signal Semantic Encoders and Local Sensitive Response Encoders. The Temporal Signal Semantic Encoder splits feature learning into high and low-frequency components, using a novel Signed Mask-Attention mechanism to emphasize important areas and downplay unimportant ones, with the features fused using ContraNorm. The Local Sensitive Response Encoder captures fluctuations without learning. These feature pyramids are then combined using a new cross-attention fusion mechanism. We also introduce a dataset with over 2,114 activity segments across 553 WiFi CSI samples, each lasting around 85 seconds. Extensive experiments show our method outperforms challenging baselines. [[paper](https://github.com/AVC2-UESTC/WiFiTAD/blob/main/mainPaper.pdf)] [[appendix](https://github.com/AVC2-UESTC/WiFiTAD/blob/main/Appendix.pdf)] 
 
  <p align="center">
@@ -9,6 +11,7 @@ We address the challenge of WiFi-based temporal activity detection and  propose 
  </p>
 
 ## Summary 
+
 - First TAD framework for wireless Temporal Activity Detection (also referred to as Temporal Activity Localization), with an untrimmed WiFi CSI dataset.
 - Powerful dual-pyramid encoders and multi-level cross-attention feature fusion.
 - Easily extansible to other signal modalities.
@@ -18,44 +21,49 @@ We address the challenge of WiFi-based temporal activity detection and  propose 
 ![](figures/performance.png)
 
 ## Getting Started
-### Dependencies & Installation
-We recommend to use conda to manage your environment, and to install PyTorch 1.12.1:
 
-```
+### Dependencies & Installation
+
+Use conda or venv to manage your environment, for example:
+
+```bash
 conda create -n wifitad python=3.8
 conda activate wifitad
+```
+
+To install dependencies and build the project, run:
+
+```bash
+pip install .
+```
+
+Note that the original was tested using:
+
+```bash
 pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu116
 ```
 
-Other packages required to support this project can be installed by running:
-
-```
-pip install -r requirements.txt
-```
-
-build the project package manager: 
-
-```
-python3 setup.py develop
-```
-
 ### Dataset Downloads
+
 WiFi Temporal Activity Detection Dataset: [link](https://drive.google.com/file/d/1gy0ppFtypVTtgBfrFzdMJUbXTb1MbPSK/view?usp=drive_link)
 
 ### Training and Tnference Example
+
 Run the traing and inference processes in terminal by: 
 
-```
+```bash
 bash TAD/train_tools/tools.sh 0,1
 ```
 
 ### Notes
+
 You may tune the hyperparameters of NMS to get wider range of TAD results.
 
 ## Citation & Acknowledgment
+
 If you find the paper and its code uesful to your research, please use the following BibTex entry.
 
-```
+```bibtex
 @article{Liu_Zhang_Li_Zhou_Chen_Zhu_2025, title={WiFi CSI Based Temporal Activity Detection via Dual Pyramid Network}, volume={39}, url={https://ojs.aaai.org/index.php/AAAI/article/view/32035}, DOI={10.1609/aaai.v39i1.32035}, number={1}, journal={Proceedings of the AAAI Conference on Artificial Intelligence}, author={Liu, Zhendong and Zhang, Le and Li, Bing and Zhou, Yingjie and Chen, Zhenghua and Zhu, Ce}, year={2025}, month={Apr.}, pages={550-558} }
 ```
 

--- a/TAD/model/encoder.py
+++ b/TAD/model/encoder.py
@@ -140,6 +140,7 @@ class Encoder2(nn.Module):
     def forward(self, q, k, v, attn_mask=None):
         # x [B, L, D]
         attns = []
+        x = None
         if self.conv_layers is not None:
             for attn_layer, conv_layer in zip(self.attn_layers, self.conv_layers):
                 x, attn = attn_layer(q, k, v, attn_mask=attn_mask)
@@ -166,6 +167,7 @@ class Encoder3(nn.Module):
     def forward(self, feat1, feat2, attn_mask=None):
         # x [B, L, D]
         attns = []
+        x = None
         for attn_layer in self.attn_layers:
             x, attn = attn_layer(feat1, feat2, attn_mask=attn_mask)
             attns.append(attn)

--- a/TAD/train_tools/tools.sh
+++ b/TAD/train_tools/tools.sh
@@ -1,8 +1,8 @@
 echo "start training"
-CUDA_VISIBLE_DEVICES=$1,$2 python3 TAD/utils/train.py configs/WiFiTAD.yaml
+CUDA_VISIBLE_DEVICES=$1,$2 python TAD/utils/train.py configs/WiFiTAD.yaml
 
 echo "start detecting..."
-CUDA_VISIBLE_DEVICES=$1 python3 TAD/utils/test.py configs/WiFiTAD.yaml
+CUDA_VISIBLE_DEVICES=$1 python TAD/utils/test.py configs/WiFiTAD.yaml
 
 echo "start eval..."
-python3 TAD/utils/eval.py configs/WiFiTAD.yaml
+python TAD/utils/eval.py configs/WiFiTAD.yaml

--- a/TAD/utils/device.py
+++ b/TAD/utils/device.py
@@ -1,0 +1,13 @@
+import torch
+
+
+def get_device() -> torch.device:
+    """
+    Pick cuda if available, else MPS (Apple Metal), else CPU.
+    """
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        return torch.device("mps")
+    else:
+        return torch.device("cpu")

--- a/TAD/utils/train.py
+++ b/TAD/utils/train.py
@@ -3,6 +3,7 @@ import os
 import random
 import torch
 import torch.nn as nn
+import torch.multiprocessing as mp
 from torch.utils.data import DataLoader
 import tqdm
 import numpy as np
@@ -11,6 +12,7 @@ from TAD.dataset.load_csi import SmartWiFi, get_video_info, \
 from TAD.model.tad_model import wifitad
 from TAD.losses.loss import MultiSegmentLoss
 from TAD.config import config
+from TAD.utils.device import get_device
 
 batch_size = config['training']['batch_size']
 learning_rate = config['training']['learning_rate']
@@ -20,7 +22,13 @@ num_classes = config['dataset']['num_classes']
 checkpoint_path = config['training']['checkpoint_path']
 focal_loss = config['training']['focal_loss']
 random_seed = config['training']['random_seed']
-ngpu = config['ngpu']
+
+device = get_device()
+ngpu = (
+    config.get('ngpu', torch.cuda.device_count())
+    if device.type == "cuda"
+    else 0
+)
 GLOBAL_SEED = 1
 
 train_state_path = os.path.join(checkpoint_path, 'training')
@@ -44,12 +52,16 @@ def print_training_info():
 
 def set_seed(seed):
     torch.manual_seed(seed)
-    torch.cuda.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
+    if device.type == "cuda":
+        # seed all CUDA devices
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        # make cuDNN deterministic
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True
+
     np.random.seed(seed)
     random.seed(seed)
-    torch.backends.cudnn.benchmark = False
-    torch.backends.cudnn.deterministic = True
 
 
 def worker_init_fn(worker_id):
@@ -57,26 +69,34 @@ def worker_init_fn(worker_id):
 
 
 def get_rng_states():
-    states = []
-    states.append(random.getstate())
-    states.append(np.random.get_state())
-    states.append(torch.get_rng_state())
-    if torch.cuda.is_available():
-        states.append(torch.cuda.get_rng_state())
+    """Capture and return RNG states for Python, NumPy, and Torch (and CUDA if used)."""
+    states = {
+        "python": random.getstate(),
+        "numpy": np.random.get_state(),
+        "torch_cpu": torch.get_rng_state()
+    }
+    if device.type == "cuda":
+        states["torch_cuda"] = torch.cuda.get_rng_state()
     return states
 
 
-def set_rng_state(states):
-    random.setstate(states[0])
-    np.random.set_state(states[1])
-    torch.set_rng_state(states[2])
-    if torch.cuda.is_available():
-        torch.cuda.set_rng_state(states[3])
+def set_rng_states(states):
+    """Restore RNG states from get_rng_states()."""
+    random.setstate(states["python"])
+    np.random.set_state(states["numpy"])
+    torch.set_rng_state(states["torch_cpu"])
+    if device.type == "cuda" and "torch_cuda" in states:
+        torch.cuda.set_rng_state(states["torch_cuda"])
 
 
 def save_model(epoch, model, optimizer):
-    torch.save(model.module.state_dict(),
-               os.path.join(checkpoint_path, 'checkpoint-{}.ckpt'.format(epoch)))
+    # if model is DataParallel, unwrap it, otherwise use it directly
+    base_model = model.module if hasattr(model, 'module') else model
+
+    torch.save(
+        base_model.state_dict(),
+        os.path.join(checkpoint_path, f'checkpoint-{epoch}.ckpt')
+    )
     # torch.save({'optimizer': optimizer.state_dict(),
     #             'state': get_rng_states()},
     #            os.path.join(train_state_path, 'checkpoint_{}.ckpt'.format(epoch)))
@@ -90,22 +110,24 @@ def resume_training(resume, model, optimizer):
         train_path = os.path.join(train_state_path, 'checkpoint_{}.ckpt'.format(resume))
         state_dict = torch.load(train_path)
         optimizer.load_state_dict(state_dict['optimizer'])
-        set_rng_state(state_dict['state'])
+        set_rng_states(state_dict['state'])
     return start_epoch
 
-def forward_one_epoch(net, clips, targets, training=True):
-    clips = clips.cuda()
-    targets = [t.cuda() for t in targets]
+def forward_one_epoch(net, clips, targets, loss_fn, training=True):
+    # send inputs to the same device as the model
+    clips = clips.to(device)
+    targets = [t.to(device) for t in targets]
     if training:
         output_dict = net(clips)
     else:
         with torch.no_grad():
             output_dict = net(clips)
 
-    loss_l, loss_c = CPD_Loss([output_dict['loc'], output_dict['conf'], output_dict["priors"][0]], targets)
+    preds = [output_dict['loc'], output_dict['conf'], output_dict["priors"][0]]
+    loss_l, loss_c = loss_fn(preds, targets)
     return loss_l, loss_c
 
-def run_one_epoch(epoch, net, optimizer, data_loader, epoch_step_num, training=True):
+def run_one_epoch(epoch, net, optimizer, data_loader, epoch_step_num, loss_fn, training=True):
     if training:
         net.train()
     else:
@@ -115,10 +137,11 @@ def run_one_epoch(epoch, net, optimizer, data_loader, epoch_step_num, training=T
     loss_loc_val = 0
     loss_conf_val = 0
     cost_val = 0
+
     with tqdm.tqdm(data_loader, total=epoch_step_num, ncols=0) as pbar:
         for n_iter, (clips, targets) in enumerate(pbar):
             iteration = n_iter
-            loss_l, loss_c= forward_one_epoch(net, clips, targets, training=training)
+            loss_l, loss_c= forward_one_epoch(net, clips, targets, loss_fn, training=training)
 
             loss_l = loss_l * config['training']['lw'] * 100
             loss_c = loss_c * config['training']['cw']
@@ -149,30 +172,37 @@ def run_one_epoch(epoch, net, optimizer, data_loader, epoch_step_num, training=T
     print(plog)
 
 
-if __name__ == '__main__':
-    print_training_info()
-    set_seed(random_seed)
+def build_model():
     """
-    Setup model
+    Create model
     """
     net = wifitad(in_channels=config['model']['in_channels'])
-    net = nn.DataParallel(net, device_ids=list(range(ngpu))).cuda()
+    # move model to device
+    net = net.to(device)
+    # wrap in DataParallel only for CUDA + multiple GPUs
+    if device.type == "cuda" and ngpu > 1:
+        net = nn.DataParallel(net, device_ids=list(range(ngpu)))
+    return net
 
+def train():
     """
-    Setup optimizer
+    Perform training
     """
+    # Setup model
+    net = build_model()
+
+    # Setup optimizer
     optimizer = torch.optim.Adam(net.parameters(),
                                  lr=learning_rate,
                                  weight_decay=weight_decay)
-    """
-    Setup loss
-    """
+    
+    # Setup loss
     piou = config['training']['piou']
     CPD_Loss = MultiSegmentLoss(num_classes, piou, 1.0, use_focal_loss=focal_loss)
 
-    """
-    Setup dataloader
-    """
+    # Setup dataloader
+    # Memory pinning only makes sense for CUDA
+    use_pin_memory = (device.type == "cuda")
     train_video_infos = get_video_info(config['dataset']['training']['csi_info_path'])
     train_video_annos = get_video_anno(train_video_infos,
                                        config['dataset']['training']['csi_anno_path'])
@@ -181,15 +211,37 @@ if __name__ == '__main__':
     train_dataset = SmartWiFi(train_data_dict,
                                    train_video_infos,
                                    train_video_annos)
-    train_data_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True,
-                                   num_workers=4, worker_init_fn=worker_init_fn,
-                                   collate_fn=detection_collate, pin_memory=True, drop_last=True)
+    train_data_loader = DataLoader(
+        train_dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=4,
+        worker_init_fn=worker_init_fn,
+        collate_fn=detection_collate,
+        pin_memory=use_pin_memory,
+        drop_last=True
+    )
+    
     epoch_step_num = len(train_dataset) // batch_size
 
-    """
-    Start training
-    """
+    # Start training
     start_epoch = resume_training(resume, net, optimizer)
     
     for i in range(start_epoch, max_epoch + 1):
-        run_one_epoch(i, net, optimizer, train_data_loader, len(train_dataset) // batch_size)
+        run_one_epoch(i, net, optimizer, train_data_loader, epoch_step_num, loss_fn=CPD_Loss)
+
+if __name__ == '__main__':
+    # NOTE: On mac and probably windows, multiprocessing doesnt fork.
+    # This causes dangling processes which deadlock on cleanup, freezing
+    # this script. This fixes such issues and should not impact the linux default.
+    try:
+        mp.set_start_method('fork', force=True)
+    except RuntimeError:
+        # if it’s already set, just move on
+        pass
+
+    print_training_info()
+    set_seed(random_seed)
+    train()
+
+    print("Training finished.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,54 @@
+# pyproject.toml
+
+[build-system]
+requires = [
+  "setuptools>=65.0",
+  "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "TAD"
+version = "1.0.0"
+description = "WiFi CSI-Based Temporal Activity Detection via Dual Pyramid Network"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "Zhendong Liu" },
+  { name = "Le Zhang" },
+  { name = "Bing Li" },
+  { name = "Yingjie Zhou" },
+  { name = "Zhenghua Chen" },
+  { name = "Ce Zhu" }
+]
+keywords = [
+  "WiFi", "CSI", "Temporal Activity Detection",
+  "Deep Learning", "PyTorch", "Computer Vision"
+]
+
+dependencies = [
+  "tqdm",
+  "pandas",
+  "joblib",
+  "pyyaml",
+  "matplotlib",
+  "torch",
+  "torchvision",
+  "torchaudio",
+]
+
+[project.urls]
+"Homepage"     = "https://github.com/AVC2-UESTC/WiFiTAD"
+"Paper"        = "https://ojs.aaai.org/index.php/AAAI/article/view/32035"
+"Code"         = "https://github.com/AVC2-UESTC/WiFiTAD"
+"Dataset"      = "https://drive.google.com/file/d/1gy0ppFtypVTtgBfrFzdMJUbXTb1MbPSK/view"
+"Bug Tracker"  = "https://github.com/AVC2-UESTC/WiFiTAD/issues"
+
+[project.scripts]
+tad-train = "TAD.train_tools.tools:main"
+tad-infer = "TAD.train_tools.tools:infer"
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["cache", "output", "dataset"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-tqdm
-pandas
-joblib
-pyyaml
-matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-from setuptools import setup, find_packages
-
-if __name__ == '__main__':
-    setup(
-        name='TAD',
-        version='1.0',
-        packages=find_packages(exclude=('cache', 'output', 'dataset'))
-    )
-    


### PR DESCRIPTION
Thanks for open sourcing! While testing, I came across some things to fix or improve. Mostly minor changes to enable venv, metal (macos) or CPU fallbacks and moving to pyproject because setup.py is being deprecated in October. While at it, I included a generic gitignore and some README updates. In summary:

- Added a gitignore to avoid accidental commits of data etc
- Moved from setup.py to pyproject because of October deprecation
- Use python instead of python3; only symlinked, but required for venv
- Default devices to torch, fallback for metal (macos) and CPU
- Requirements now in pyproject.toml; simplified setup
- Minor refactoring changes